### PR TITLE
Extract input device config to own module

### DIFF
--- a/nix/modules/darwin-configuration.nix
+++ b/nix/modules/darwin-configuration.nix
@@ -7,6 +7,7 @@
   ...
 }: {
   imports = [
+    ./input-devices.nix
     ./nix-configuration.nix
   ];
 
@@ -324,12 +325,6 @@
 
   system = {
     defaults.SoftwareUpdate.AutomaticallyInstallMacOSUpdates = true;
-
-    keyboard = {
-      enableKeyMapping = true;
-      remapCapsLockToControl = true;
-    };
-
     stateVersion = 4;
   };
 }

--- a/nix/modules/home-configuration.nix
+++ b/nix/modules/home-configuration.nix
@@ -7,6 +7,7 @@
   imports = [
     ./emacs.nix
     ./i3.nix
+    ./input-devices.nix
     ./nix-configuration.nix
     ./shell.nix
   ];
@@ -142,12 +143,6 @@
         executable = true;
         source = ../../home/${config.lib.local.xdg.bin.rel}/git-ls-subtrees;
       };
-    };
-
-    keyboard = {
-      layout = "us";
-      options = ["ctrl:nocaps"];
-      variant = "dvorak";
     };
 
     ## TODO: Replace these with my ./locale.nix module

--- a/nix/modules/input-devices.nix
+++ b/nix/modules/input-devices.nix
@@ -1,0 +1,52 @@
+{
+  config,
+  options,
+  lib,
+  pkgs,
+  ...
+}: {
+  config =
+    if options ? homebrew
+    then {
+      homebrew.casks = [
+        # Atreus keyboard customizer
+        "chrysalis" # not available on darwin via Nix
+      ];
+      system.keyboard = {
+        enableKeyMapping = true;
+        remapCapsLockToControl = true;
+      };
+    }
+    else if options ? home
+    then {
+      home = {
+        keyboard = {
+          layout = "us";
+          options = ["ctrl:nocaps"];
+          variant = "dvorak";
+        };
+        packages = lib.optionals (pkgs.system == "x86_64-linux") [
+          # Atreus keyboard customizer
+          pkgs.chrysalis # packaged as x86_64-linux binary
+        ];
+      };
+    }
+    else {
+      console.useXkbConfig = true;
+      services = {
+        fprintd.enable = true;
+        xserver = {
+          layout = "us, dvorak";
+          # Enable touchpad support.
+          libinput = {
+            touchpad = {
+              clickMethod = "clickfinger"; # don't right-click on right side of touchpad
+              naturalScrolling = true;
+              tapping = false; # disable tap-to-click
+            };
+          };
+          xkbOptions = "ctrl:nocaps";
+        };
+      };
+    };
+}

--- a/nix/modules/nixos-configuration.nix
+++ b/nix/modules/nixos-configuration.nix
@@ -5,6 +5,7 @@
   ...
 }: {
   imports = [
+    ./input-devices.nix
     ./nix-configuration.nix
   ];
 
@@ -24,10 +25,7 @@
     systemd-boot.enable = true;
   };
 
-  console = {
-    font = "Lat2-Terminus16";
-    useXkbConfig = true;
-  };
+  console.font = "Lat2-Terminus16";
 
   environment = {
     extraOutputsToInstall = ["devdoc" "doc" "man"];
@@ -148,8 +146,6 @@
 
     blueman.enable = true;
 
-    fprintd.enable = true;
-
     openssh.enable = false; # subsumed by tailscale
 
     pipewire = {
@@ -183,17 +179,7 @@
         enable = true;
       };
       enable = true;
-      layout = "us, dvorak";
-      # Enable touchpad support.
-      libinput = {
-        touchpad = {
-          clickMethod = "clickfinger"; # don't right-click on right side of touchpad
-          naturalScrolling = true;
-          tapping = false; # disable tap-to-click
-        };
-      };
       windowManager.i3.enable = true;
-      xkbOptions = "ctrl:nocaps";
     };
   };
 


### PR DESCRIPTION
This is my first cross-configuration module – it can be imported in nixos,
nix-darwin, or home-manager.