### PR TITLE
Add a VCS module

### DIFF
--- a/nix/modules/darwin-configuration.nix
+++ b/nix/modules/darwin-configuration.nix
@@ -9,6 +9,7 @@
   imports = [
     ./input-devices.nix
     ./nix-configuration.nix
+    ./vcs.nix
   ];
 
   environment = {
@@ -16,16 +17,6 @@
     extraOutputsToInstall = ["devdoc" "doc"];
     pathsToLink = ["/share/fonts"];
     systemPackages = [
-      ## source control -- good to have globally, so users can fetch initial
-      ## configurations
-      pkgs.breezy
-      pkgs.cvs
-      pkgs.darcs
-      # not doing `git = super.gitFull` in the overlay, because then everything
-      # gets rebuilt, but want it here for email support
-      pkgs.gitFull
-      pkgs.pijul
-      pkgs.subversion
       ## remote connections
       pkgs.mosh
       ## Nix

--- a/nix/modules/home-configuration.nix
+++ b/nix/modules/home-configuration.nix
@@ -10,6 +10,7 @@
     ./input-devices.nix
     ./nix-configuration.nix
     ./shell.nix
+    ./vcs.nix
   ];
 
   fonts.fontconfig.enable = true;
@@ -131,18 +132,6 @@
         executable = true;
         source = ../../home/${config.lib.local.xdg.bin.rel}/emacs-pager;
       };
-      "${config.lib.local.xdg.bin.rel}/git-bare" = {
-        executable = true;
-        source = ../../home/${config.lib.local.xdg.bin.rel}/git-bare;
-      };
-      "${config.lib.local.xdg.bin.rel}/git-gc-branches" = {
-        executable = true;
-        source = ../../home/${config.lib.local.xdg.bin.rel}/git-gc-branches;
-      };
-      "${config.lib.local.xdg.bin.rel}/git-ls-subtrees" = {
-        executable = true;
-        source = ../../home/${config.lib.local.xdg.bin.rel}/git-ls-subtrees;
-      };
     };
 
     ## TODO: Replace these with my ./locale.nix module
@@ -215,19 +204,14 @@
         pkgs.agenix
         pkgs.awscli
         pkgs.bash-strict-mode
-        pkgs.breezy
-        pkgs.cookiecutter
-        pkgs.darcs
         pkgs.dtach
         # pkgs.discord # currently subsumed by ferdium
         # pkgs.element-desktop # currently subsumed by ferdium
         pkgs.ghostscript
-        pkgs.git-revise # unfortunately not supported by magit
         # pkgs.gitter # currently subsumed by ferdium
         pkgs.imagemagick
         pkgs.jekyll
         pkgs.magic-wormhole
-        pkgs.mosh # SSH client replacement
         (pkgs.nerdfonts.override {
           fonts =
             lib.concatMap
@@ -237,14 +221,10 @@
               else [])
             fonts;
         })
-        pkgs.pijul
-        pkgs.pinentry.tty
         # pkgs.slack # currently subsumed by ferdium
         pkgs.synergy
         pkgs.tailscale
         pkgs.tikzit
-        pkgs.tree
-        pkgs.wget
         # pkgs.wire-desktop # currently subsumed by ferdium
       ]
       ++ map (font: font.package) fonts
@@ -289,7 +269,6 @@
 
     sessionVariables = {
       ALTERNATIVE_EDITOR = "${pkgs.emacs}/bin/emacs";
-      BRZ_LOG = "${config.xdg.stateHome}/breezy/log";
       CABAL_CONFIG = "${config.home.homeDirectory}/${config.xdg.configFile."cabal/config".target}";
       CABAL_DIR = "${config.xdg.stateHome}/cabal";
       CARGO_HOME = "${config.xdg.cacheHome}/cargo";
@@ -533,75 +512,6 @@
           }
         '';
       };
-    };
-
-    git = {
-      aliases = {
-        ## List contributors ordered by number of commits.
-        brag-commits = "shortlog --numbered --summary";
-        ## Log output that approximates Magit under Solarized.
-        lg = "log --color --graph --pretty=format:\"%Cblue%h%Creset %Cgreen%D%Creset %s %>|($((\"$COLUMNS\" - 7)))%C(cyan)%an%Creset %>(6,trunc)%cr\"";
-      };
-      attributes = ["*.lisp diff=lisp"];
-      enable = true;
-      extraConfig = {
-        diff.algrithm = "histogram";
-        init = {
-          defaultBranch = "main";
-          templateDir = config.xdg.configFile."git/template".target;
-        };
-        log.showSignatures = true;
-        merge.conflictStyle = "diff3";
-        rebase.autosquash = true;
-        sendemail.identity = config.lib.local.primaryEmailAccountName;
-        ## TODO: Stuff from my old .gitconfig that needs to be reviewed
-        diff."lisp".xfuncname = "^(\\((def|test).*)$";
-        filter = {
-          "hawser" = {
-            clean = "git hawser clean %f";
-            required = true;
-            smudge = "git hawser smudge %f";
-          };
-          "media" = {
-            clean = "git media clean %f";
-            required = true;
-            smudge = "git media smudge %f";
-          };
-        };
-        mergetool.keepBackup = false;
-      };
-      ignores =
-        [
-          ".cache/" # semi-standard XDG-like cache directory
-          ".dir-locals-2.el" # Local emacs config for repos that have a config.
-          ".local/" # less standard XDG-like local directory
-
-          # Directories potentially created on network file systems
-          ".AppleDB/" # created by Macs
-          ".AppleDesktop" # created by Macs
-          ".TemporaryItems/" # created by Macs
-          ".apdisk" # created by Macs
-
-          # Floobits
-          ".floo"
-          ".flooignore"
-        ]
-        ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
-          # https://en.wikipedia.org/wiki/AppleSingle_and_AppleDouble_formats#Usage
-          ".AppleDouble/"
-          # https://en.wikipedia.org/wiki/.DS_Store
-          ".DS_Store"
-          ".LSOverride"
-          # https://en.wikipedia.org/wiki/AppleSingle_and_AppleDouble_formats#Usage
-          "._*"
-        ];
-      lfs.enable = true;
-      # not doing `git = super.gitFull` in the overlay, because then everything
-      # gets rebuilt, but want it here for email support
-      package = pkgs.gitFull;
-      signing.signByDefault = true;
-      userEmail = config.lib.local.primaryEmailAccount.address;
-      userName = config.lib.local.primaryEmailAccount.realName;
     };
 
     gpg = {
@@ -880,10 +790,6 @@
         set history filename ${config.xdg.stateHome}/gdb/history
         set history save on
       '';
-      "git/template" = {
-        recursive = true;
-        source = ../../home/${config.lib.local.xdg.config.rel}/git/template;
-      };
       "irb/irbrc".text = ''
         IRB.conf[:EVAL_HISTORY] = 200
         IRB.conf[:HISTORY_FILE] = "${config.xdg.stateHome}/irb/history"

--- a/nix/modules/nixos-configuration.nix
+++ b/nix/modules/nixos-configuration.nix
@@ -7,6 +7,7 @@
   imports = [
     ./input-devices.nix
     ./nix-configuration.nix
+    ./vcs.nix
   ];
 
   # TODO: Fix upstream. We shouldn’t need this, but it only has the correct
@@ -30,16 +31,6 @@
   environment = {
     extraOutputsToInstall = ["devdoc" "doc" "man"];
     systemPackages = [
-      ## source control – good to have globally, so users can fetch initial
-      ## configurations
-      pkgs.breezy
-      pkgs.cvs
-      pkgs.darcs
-      # not doing `git = super.gitFull` in the overlay, because then everything
-      # gets rebuilt, but want it here for email support
-      pkgs.gitFull
-      pkgs.pijul
-      pkgs.subversion
       ## Nix
       pkgs.home-manager
       pkgs.nix-du

--- a/nix/modules/shell.nix
+++ b/nix/modules/shell.nix
@@ -4,6 +4,17 @@
   pkgs,
   ...
 }: {
+  home = {
+    packages = [
+      pkgs.mosh # SSH client replacement
+      pkgs.pinentry.tty
+      pkgs.tree
+      pkgs.viddy
+      pkgs.wget
+    ];
+    shellAliases.watch = "viddy";
+  };
+
   programs = {
     ## shell history database
     atuin = {

--- a/nix/modules/vcs.nix
+++ b/nix/modules/vcs.nix
@@ -1,0 +1,156 @@
+## source control – good to have globally, so users can fetch initial
+## configurations
+{
+  config,
+  lib,
+  options,
+  pkgs,
+  ...
+}: let
+  commonPackages = [
+    pkgs.breezy
+    pkgs.cvs
+    pkgs.darcs
+    pkgs.pijul
+    pkgs.subversion
+  ];
+
+  # not doing `git = super.gitFull` in the overlay, because then everything
+  # gets rebuilt, but want it here for email support
+  gitPackage = pkgs.gitFull;
+
+  mercurialPackage = pkgs.mercurial;
+
+  ## FIXME: This is shared between Git and Mercurial, but I don"t think the
+  ##        syntax is actually the same, so need to post-process this list
+  ##        appropriately.
+  ignores =
+    [
+      ".cache/" # semi-standard XDG-like cache directory
+      ".dir-locals-2.el" # Local emacs config for repos that have a config.
+      ".local/" # less standard XDG-like local directory
+
+      # Directories potentially created on network file systems
+      ".AppleDB/" # created by Macs
+      ".AppleDesktop" # created by Macs
+      ".TemporaryItems/" # created by Macs
+      ".apdisk" # created by Macs
+
+      # Floobits
+      ".floo"
+      ".flooignore"
+    ]
+    ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+      # https://en.wikipedia.org/wiki/AppleSingle_and_AppleDouble_formats#Usage
+      ".AppleDouble/"
+      # https://en.wikipedia.org/wiki/.DS_Store
+      ".DS_Store"
+      ".LSOverride"
+      # https://en.wikipedia.org/wiki/AppleSingle_and_AppleDouble_formats#Usage
+      "._*"
+    ];
+in {
+  config =
+    if options ? homebrew
+    then {
+      environment.systemPackages =
+        commonPackages
+        ++ [
+          gitPackage
+          mercurialPackage
+        ];
+    }
+    else if options ? home
+    then {
+      home = {
+        file = builtins.listToAttrs (map (command:
+          lib.nameValuePair
+          "${config.lib.local.xdg.bin.rel}/${command}"
+          {
+            executable = true;
+            source = ../../home/${config.lib.local.xdg.bin.rel}/${command};
+          }) [
+          "git-bare"
+          "git-gc-branches"
+          "git-ls-subtrees"
+        ]);
+        packages =
+          commonPackages
+          ++ [
+            pkgs.git-revise # unfortunately not supported by magit
+          ];
+        sessionVariables.BRZ_LOG = "${config.xdg.stateHome}/breezy/log";
+      };
+
+      programs = {
+        git = {
+          aliases = {
+            ## List contributors ordered by number of commits.
+            brag-commits = "shortlog --numbered --summary";
+            ## Log output that approximates Magit under Solarized.
+            lg = "log --color --graph --pretty=format:\"%Cblue%h%Creset %Cgreen%D%Creset %s %>|($((\"$COLUMNS\" - 7)))%C(cyan)%an%Creset %>(6,trunc)%cr\"";
+          };
+          attributes = ["*.lisp diff=lisp"];
+          enable = true;
+          extraConfig = {
+            diff.algorithm = "histogram";
+            init = {
+              defaultBranch = "main";
+              templateDir = config.lib.local.addHome config.xdg.configFile."git/template".target;
+            };
+            log.showSignatures = true;
+            merge.conflictStyle = "diff3";
+            rebase.autosquash = true;
+            sendemail.identity = config.lib.local.primaryEmailAccountName;
+            ## TODO: Stuff from my old .gitconfig that needs to be reviewed
+            diff."lisp".xfuncname = "^(\\((def|test).*)$";
+            filter = {
+              "hawser" = {
+                clean = "git hawser clean %f";
+                required = true;
+                smudge = "git hawser smudge %f";
+              };
+              "media" = {
+                clean = "git media clean %f";
+                required = true;
+                smudge = "git media smudge %f";
+              };
+            };
+            mergetool.keepBackup = false;
+          };
+          ignores = ignores;
+          lfs.enable = true;
+          # not doing `git = super.gitFull` in the overlay, because then everything
+          # gets rebuilt, but want it here for email support
+          package = gitPackage;
+          signing.signByDefault = true;
+          userEmail = config.lib.local.primaryEmailAccount.address;
+          userName = config.lib.local.primaryEmailAccount.realName;
+        };
+
+        mercurial = {
+          enable = true;
+          ignores = ignores;
+          package = pkgs.mercurial;
+          userEmail = config.lib.local.primaryEmailAccount.address;
+          userName = config.lib.local.primaryEmailAccount.realName;
+        };
+      };
+
+      xdg.configFile."git/template" = {
+        recursive = true;
+        source = ../../home/${config.lib.local.xdg.config.rel}/git/template;
+      };
+    }
+    else {
+      environment.systemPackages =
+        commonPackages
+        ++ [
+          mercurialPackage
+        ];
+      programs.git = {
+        enable = true;
+        package = gitPackage;
+      };
+    };
+}


### PR DESCRIPTION
This also
- fixes the Git `diff.algorithm` setting,
- moves a few more things to the shell module, and
- adds `viddy` as a `watch` replacement.