### PR TITLE
Install home-manager as used by this flake

### DIFF
--- a/.config/project/default.nix
+++ b/.config/project/default.nix
@@ -1,4 +1,4 @@
-{config, lib, ...}: {
+{config, lib, pkgs, ...}: {
   project = {
     name = "dotfiles";
     summary = "Sellout’s general configuration";
@@ -6,6 +6,8 @@
     ## contributable-to by non-Nix users. However, Nix-specific projects can
     ## lean into Project Manager and avoid committing extra files.
     commit-by-default = lib.mkForce false;
+
+    devPackages = [pkgs.home-manager];
   };
 
   ## dependency management

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
           inherit
             emacs-color-theme-solarized
             flake-utils
+            home-manager
             mkalias
             nixpkgs
             unison

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,6 +1,7 @@
 {
   emacs-color-theme-solarized,
   flake-utils,
+  home-manager,
   mkalias,
   nixpkgs,
   nixpkgsConfig,
@@ -111,6 +112,10 @@ in {
           ];
       });
     });
+
+  ## Use the home-manager from our inputs (but it doesn’t provide an overlay
+  ## itself).
+  home-manager = home-manager.packages.${final.system}.home-manager;
 
   ## Idris 1 doesn’t build on Nixpkgs 23.11.
   idris = final.idris2;


### PR DESCRIPTION
Ensures that the version of home-manager installed by the flake is the same one used to define the configuration. Also installs it as a dev package.