### PR TITLE
Add Auto-Dark to Emacs

### DIFF
--- a/home/.config/emacs/init.el
+++ b/home/.config/emacs/init.el
@@ -86,6 +86,11 @@
 
 (use-package agenix)
 
+(use-package auto-dark
+  :after custom
+  :defer nil
+  :init (auto-dark-mode))
+
 (use-package autorevert
   :custom (auto-revert-mode-text "↩"))
 

--- a/nix/modules/emacs.nix
+++ b/nix/modules/emacs.nix
@@ -278,6 +278,7 @@
       # epkgs.agda2-mode # fails while linking Agda-2.6.2.2
       epkgs.agenix
       epkgs.applescript-mode
+      epkgs.auto-dark
       epkgs.auto-dim-other-buffers
       epkgs.bats-mode
       epkgs.bradix

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -26,6 +26,15 @@ in {
   emacs = final.emacs29;
   emacsPackagesFor = emacs:
     (prev.emacsPackagesFor emacs).overrideScope' (efinal: eprev: {
+      auto-dark = eprev.auto-dark.overrideAttrs (old: {
+        ## adds `frame-background-mode` support (LionyxML/auto-dark-emacs#57)
+        src = final.fetchFromGitHub {
+          owner = "sellout";
+          repo = "auto-dark-emacs";
+          rev = "default-to-custom-enabled-themes";
+          sha256 = "D+bXR9zVDLDnsuOn6NT3mboeciyQiPIGLAHmokY15nI=";
+        };
+      });
       ## still waffling between `direnv` and `envrc`. `direnv` has at least an
       ## attempt at TRAMP support, but `envrc` seems generally better.
       direnv = eprev.direnv.overrideAttrs (old: {


### PR DESCRIPTION
This minor mode auto-toggles dark mode with the system.