### PR TITLE
Add configuration examples for all supported systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -124,10 +124,7 @@
               modules = [self.darwinModules.darwin];
             };
           })
-          [
-            flake-utils.lib.system.aarch64-darwin
-            flake-utils.lib.system.x86_64-darwin
-          ]);
+          (builtins.filter (nixpkgs.lib.hasSuffix "darwin") supportedSystems));
 
       homeConfigurations =
         builtins.listToAttrs
@@ -191,10 +188,7 @@
               ];
             };
           })
-          [
-            # flake-utils.lib.system.aarch64-linux
-            flake-utils.lib.system.x86_64-linux
-          ]);
+          (builtins.filter (nixpkgs.lib.hasSuffix "linux") supportedSystems));
     }
     // flake-utils.lib.eachSystem supportedSystems (system: let
       pkgs = import nixpkgs {inherit system;};

--- a/nix/modules/emacs/init.el
+++ b/nix/modules/emacs/init.el
@@ -28,17 +28,6 @@
 
 ;;; Code:
 
-;; TODO: We force default.el to load before init.el because it’s set up via Nix,
-;;       and provides useful values for the rest of the initialization.
-;;       Longer-term, this might not be necessary, once we move most of the
-;;       Nix-based configuration to overlays that are then included in
-;;       site-start.el. The remaining config in default will _probably_ make
-;;       sense to load after this file. (And `inhibit-default-init' should also
-;;       be un-customized at that point.) See
-;;       https://www.gnu.org/software/emacs/manual/html_node/elisp/Startup-Summary.html
-;;       for details about what happens when during startup.
-(load "default")
-
 (defun require-config (feature)
   "Like ‘require’, but first look for FEATURE in ‘user-emacs-directory’."
   (let ((load-path (cons user-emacs-directory load-path)))
@@ -47,7 +36,6 @@
 (require-config 'xdg-locations)
 
 (custom-set-variables
- '(inhibit-default-init t nil () "We force loading it _before_ init.el.")
  ;; NB: If this isn’t set in _this_ file, Emacs will ignore it by design.
  '(inhibit-startup-screen t nil () "Explicitly set in `user-init-file`."))
 

--- a/nix/modules/nixos-configuration.nix
+++ b/nix/modules/nixos-configuration.nix
@@ -64,6 +64,9 @@
 
   hardware = {
     bluetooth.enable = true;
+    ## `programs.steam.enable` sets this to `true`, but it only works on
+    ## x86_64-linux (despite its claim that it works on any 64-bit system).
+    opengl.driSupport32Bit = lib.mkForce (pkgs.system == "x86_64-linux");
     pulseaudio.enable = false;
   };
 
@@ -116,7 +119,7 @@
     mosh.enable = true;
     # mtr.enable = true;
     steam = {
-      enable = true;
+      enable = pkgs.system != "aarch64-linux";
       remotePlay.openFirewall = true;
       dedicatedServer.openFirewall = true;
     };


### PR DESCRIPTION
This also fixes the failures these examples expose.

And it also contains some changes that should have been in #29.