### PR TITLE
Adjust the Emacs configuration

### DIFF
--- a/nix/modules/emacs/default.el
+++ b/nix/modules/emacs/default.el
@@ -28,16 +28,12 @@
 
 ;;; Code:
 
-(defun require-config (feature)
+(defun require-config (feature &optional filename noerror)
   "Like ‘require’, but first look for FEATURE in ‘user-emacs-directory’."
   (let ((load-path (cons user-emacs-directory load-path)))
-    (require feature)))
+    (require feature filename noerror)))
 
 (require-config 'xdg-locations)
-
-(custom-set-variables
- ;; NB: If this isn’t set in _this_ file, Emacs will ignore it by design.
- '(inhibit-startup-screen t nil () "Explicitly set in `user-init-file`."))
 
 (xdg-locations-custom-paths)
 
@@ -61,6 +57,10 @@
 ;; NB: Need these ones first, because use-package uses them in other clauses.
 (use-package bind-key)
 (use-package delight)
+
+;; This is a escape hatch for loading non-Nix-managed configuration local to the
+;; user account. See the contents of ‘user-init-file’ for more information.
+(require-config 'local nil nil)
 
 (use-package abbrev
   :delight "…")

--- a/nix/modules/emacs/default.nix
+++ b/nix/modules/emacs/default.nix
@@ -119,220 +119,225 @@
     #   buildInputs = [ pkgs.dbus ] ++ old.buildInputs;
     # });
     package = pkgs.emacs29;
-    extraConfig = ''
-      ;;; -*- lexical-binding: t; -*-
+    extraConfig =
+      ''
+        ;;; -*- lexical-binding: t; -*-
 
-      (require 'custom-pseudo-theme)
+        (require 'custom-pseudo-theme)
 
-      ;; Ideally, environment variables would be set more generally (outside
-      ;; of Emacs), but setting things like ‘launchd.envVariables’,
-      ;; ‘launchd.user.envVariables’, etc. doesn't seem to have an effect.
-      ${lib.concatStringsSep "\n"
-        (lib.mapAttrsToList
-          (var: value: "(setenv \"${var}\" \"${value}\")")
-          config.home.sessionVariables)}
+        ;; Ideally, environment variables would be set more generally (outside
+        ;; of Emacs), but setting things like ‘launchd.envVariables’,
+        ;; ‘launchd.user.envVariables’, etc. doesn't seem to have an effect.
+        ${lib.concatStringsSep "\n"
+          (lib.mapAttrsToList
+            (var: value: "(setenv \"${var}\" \"${value}\")")
+            config.home.sessionVariables)}
 
-      ;; TODO: Add these via a flake input … but need it to be in git or hg.
-      (add-to-list 'load-path "${inputs.emacs-color-theme-solarized}")
+        ;; TODO: Add these via a flake input … but need it to be in git or hg.
+        (add-to-list 'load-path "${inputs.emacs-color-theme-solarized}")
 
-      ;;; This contains settings we want to customize with Nix-dependent values,
-      ;;; organized by package.
+        ;;; This contains settings we want to customize with Nix-dependent values,
+        ;;; organized by package.
 
-      ;;; The setup for paths is split into two groups – the first is global
-      ;;; settings, generally where we expect to always use the Emacs-side
-      ;;; binary for things. The second is local settings, where we only want to
-      ;;; use the Emacs-side binary for local buffers. However, there is another
-      ;;; use case – we can also set values we want used for remote instances in
-      ;;; the first group, then use the second group to override them for local
-      ;;; instances. We should comment in both places when this is done.
+        ;;; The setup for paths is split into two groups – the first is global
+        ;;; settings, generally where we expect to always use the Emacs-side
+        ;;; binary for things. The second is local settings, where we only want to
+        ;;; use the Emacs-side binary for local buffers. However, there is another
+        ;;; use case – we can also set values we want used for remote instances in
+        ;;; the first group, then use the second group to override them for local
+        ;;; instances. We should comment in both places when this is done.
 
-      (custom-pseudo-theme-set-variables 'sellout-system-configurations-nix-path
-        ;; Emacs packages
+        (custom-pseudo-theme-set-variables 'sellout-system-configurations-nix-path
+          ;; Emacs packages
 
-        ;; ispell
-        '(ispell-program-name "${pkgs.ispell}/bin/ispell")
+          ;; ispell
+          '(ispell-program-name "${pkgs.ispell}/bin/ispell")
 
-        ;; third-party packages
+          ;; third-party packages
 
-        ;; editorconfig
-        '(editorconfig-exec-path "${pkgs.editorconfig-core-c}/bin/editorconfig")
-        ;; flycheck
-        '(flycheck-rust-binary-name "${pkgs.rustc}/bin/rustc")
-        '(flycheck-rust-executable "${pkgs.rustc}/bin/rustc")
-        '(flycheck-sh-bash-executable "${pkgs.bash}/bin/bash")
-        '(flycheck-sh-posix-bash-executable "${pkgs.bash}/bin/bash")
-        '(flycheck-sh-shellcheck-executable "${pkgs.shellcheck}/bin/shellcheck")
-        '(flycheck-sh-zsh-executable "${pkgs.zsh}/bin/zsh")
-        ;; flycheck-vale
-        '(flycheck-vale-program "${pkgs.vale}/bin/vale")
-        ;; wakatime-mode
-        ;; wakatime/wakatime-mode#67
-        '(wakatime-cli-path "${pkgs.wakatime}/bin/wakatime-cli"))
+          ;; editorconfig
+          '(editorconfig-exec-path "${pkgs.editorconfig-core-c}/bin/editorconfig")
+          ;; flycheck
+          '(flycheck-rust-binary-name "${pkgs.rustc}/bin/rustc")
+          '(flycheck-rust-executable "${pkgs.rustc}/bin/rustc")
+          '(flycheck-sh-bash-executable "${pkgs.bash}/bin/bash")
+          '(flycheck-sh-posix-bash-executable "${pkgs.bash}/bin/bash")
+          '(flycheck-sh-shellcheck-executable "${pkgs.shellcheck}/bin/shellcheck")
+          '(flycheck-sh-zsh-executable "${pkgs.zsh}/bin/zsh")
+          ;; flycheck-vale
+          '(flycheck-vale-program "${pkgs.vale}/bin/vale")
+          ;; wakatime-mode
+          ;; wakatime/wakatime-mode#67
+          '(wakatime-cli-path "${pkgs.wakatime}/bin/wakatime-cli"))
 
-      ;; This should be moved to an upstream overlay containing settings for full
-      ;; Nix-store paths.
-      (custom-pseudo-theme-set-local-variables
-          'sellout-system-configurations-nix-path
-        ;; Emacs packages
-        '(octave
-          (inferior-octave-program "${pkgs.octave}/bin/octave"))
-        '(tex-mode
-          ;; TODO: These can’t go upstream like this – how to depend on the
-          ;;       individual binaries correctly?
-          (latex-run-command "${texlive-combined}/bin/latex")
-          (slitex-run-command nil nil () "I can’t find this command anywhere")
-          (tex-bibtex-command "${texlive-combined}/bin/bibtex")
-          (tex-run-command "${texlive-combined}/bin/tex"))
-        '(vc-darcs
-          (vc-darcs-program-name "${pkgs.darcs}/bin/darcs"))
+        ;; This should be moved to an upstream overlay containing settings for full
+        ;; Nix-store paths.
+        (custom-pseudo-theme-set-local-variables
+            'sellout-system-configurations-nix-path
+          ;; Emacs packages
+          '(octave
+            (inferior-octave-program "${pkgs.octave}/bin/octave"))
+          '(tex-mode
+            ;; TODO: These can’t go upstream like this – how to depend on the
+            ;;       individual binaries correctly?
+            (latex-run-command "${texlive-combined}/bin/latex")
+            (slitex-run-command nil nil () "I can’t find this command anywhere")
+            (tex-bibtex-command "${texlive-combined}/bin/bibtex")
+            (tex-run-command "${texlive-combined}/bin/tex"))
+          '(vc-darcs
+            (vc-darcs-program-name "${pkgs.darcs}/bin/darcs"))
 
-        ;; third-party packages
-        '(agenix
-          (agenix-age-program "${pkgs.age}/bin/age"))
-        '(darcsum
-          (darcsum-program "${pkgs.darcs}/bin/darcs"))
-        '(detached
-          (detached-dtach-program "${pkgs.dtach}/bin/dtach"))
-        '(dhall-mode
-          (dhall-command "${pkgs.dhall}/bin/dhall"))
-        '(envrc
-          (envrc-direnv-executable "${pkgs.direnv}/bin/direnv"))
-        '(floobits
-          (floobits-python-executable "${pkgs.python}/bin/python"))
-        '(flycheck
-          (flycheck-rust-cargo-executable "${pkgs.cargo}/bin/cargo"))
-        '(ggtags
-          (ggtags-executable-directory "${pkgs.global}/bin/"))
-        '(graphviz-dot-mode
-          (graphviz-dot-dot-program "${pkgs.graphviz}/bin/dot")
-          (graphviz-dot-layout-programs
-           '("${pkgs.graphviz}/bin/dot"
-             "${pkgs.graphviz}/bin/neato"
-             "${pkgs.graphviz}/bin/fdp"
-             "${pkgs.graphviz}/bin/sfdp"
-             "${pkgs.graphviz}/bin/twopi"
-             "${pkgs.graphviz}/bin/circo"))
-          (graphviz-dot-view-command "${pkgs.graphviz}/bin/dotty %s"))
-        '(helm-rg
-          (helm-rg-git-executable "${pkgs.git}/bin/git")
-          (helm-rg-ripgrep-executable "${pkgs.ripgrep}/bin/ripgrep"))
-        '(idris-mode
-          (idris-interpreter-path "${pkgs.idris}/bin/idris"))
-        '(lsp-nix
-          (lsp-nix-nil-server-path "${pkgs.nil}/bin/nil"))
-        '(lsp-pylsp
-          (lsp-pylsp-server-command
-           '("${pkgs.pythonPackages.python-lsp-server}/bin/pylsp")))
-        '(lsp-rust
-          (lsp-rust-analyzer-server-command
-           '("${pkgs.rust-analyzer}/bin/rust-analyzer")))
-        '(magit
-          (magit-git-executable "${pkgs.git}/bin/git"))
-        '(markdown-mode
-          (markdown-command "${pkgs.pandoc}/bin/pandoc"))
-        '(nix-mode
-          (nix-build-executable "${pkgs.nix}/bin/nix-build")
-          (nix-executable "${pkgs.nix}/bin/nix")
-          (nix-instantiate-executable "${pkgs.nix}/bin/nix-instantiate")
-          (nix-nixfmt-bin "${pkgs.nixfmt}/bin/nixfmt")
-          (nix-shell-executable "${pkgs.nix}/bin/nix-shell")
-          (nix-store-executable "${pkgs.nix}/bin/nix-store"))
-        '(ormolu
-          (ormolu-process-path "${pkgs.ormolu}/bin/ormolu"))
-        '(projectile
-          (projectile-darcs-command "${pkgs.darcs}/bin/darcs show files -0 ."))
-        '(rustic
-          (rustic-rustfmt-bin "${pkgs.rustfmt}/bin/rustfmt"))
-        '(sbt-mode
-          (sbt:program-name "${pkgs.sbt}/bin/sbt"))
-        '(treemacs
-          (treemacs-python-executable "${pkgs.python}/bin/python"))
-        '(vc-pijul
-          (vc-pijul-program-name "${pkgs.pijul}/bin/pijul")))
+          ;; third-party packages
+          '(agenix
+            (agenix-age-program "${pkgs.age}/bin/age"))
+          '(darcsum
+            (darcsum-program "${pkgs.darcs}/bin/darcs"))
+          '(detached
+            (detached-dtach-program "${pkgs.dtach}/bin/dtach"))
+          '(dhall-mode
+            (dhall-command "${pkgs.dhall}/bin/dhall"))
+          '(envrc
+            (envrc-direnv-executable "${pkgs.direnv}/bin/direnv"))
+          '(floobits
+            (floobits-python-executable "${pkgs.python}/bin/python"))
+          '(flycheck
+            (flycheck-rust-cargo-executable "${pkgs.cargo}/bin/cargo"))
+          '(ggtags
+            (ggtags-executable-directory "${pkgs.global}/bin/"))
+          '(graphviz-dot-mode
+            (graphviz-dot-dot-program "${pkgs.graphviz}/bin/dot")
+            (graphviz-dot-layout-programs
+             '("${pkgs.graphviz}/bin/dot"
+               "${pkgs.graphviz}/bin/neato"
+               "${pkgs.graphviz}/bin/fdp"
+               "${pkgs.graphviz}/bin/sfdp"
+               "${pkgs.graphviz}/bin/twopi"
+               "${pkgs.graphviz}/bin/circo"))
+            (graphviz-dot-view-command "${pkgs.graphviz}/bin/dotty %s"))
+          '(helm-rg
+            (helm-rg-git-executable "${pkgs.git}/bin/git")
+            (helm-rg-ripgrep-executable "${pkgs.ripgrep}/bin/ripgrep"))
+          '(idris-mode
+            (idris-interpreter-path "${pkgs.idris}/bin/idris"))
+          '(lsp-nix
+            (lsp-nix-nil-server-path "${pkgs.nil}/bin/nil"))
+          '(lsp-pylsp
+            (lsp-pylsp-server-command
+             '("${pkgs.pythonPackages.python-lsp-server}/bin/pylsp")))
+          '(lsp-rust
+            (lsp-rust-analyzer-server-command
+             '("${pkgs.rust-analyzer}/bin/rust-analyzer")))
+          '(magit
+            (magit-git-executable "${pkgs.git}/bin/git"))
+          '(markdown-mode
+            (markdown-command "${pkgs.pandoc}/bin/pandoc"))
+          '(nix-mode
+            (nix-build-executable "${pkgs.nix}/bin/nix-build")
+            (nix-executable "${pkgs.nix}/bin/nix")
+            (nix-instantiate-executable "${pkgs.nix}/bin/nix-instantiate")
+            (nix-nixfmt-bin "${pkgs.nixfmt}/bin/nixfmt")
+            (nix-shell-executable "${pkgs.nix}/bin/nix-shell")
+            (nix-store-executable "${pkgs.nix}/bin/nix-store"))
+          ;; NB: This (and probably plenty of other settings currently in here) is
+          ;;     project-specific, and should inherit whatever’s in the context of
+          ;;     the project, rather than some global value.
+          ;; '(ormolu
+          ;;   (ormolu-process-path "${pkgs.ormolu}/bin/ormolu"))
+          '(projectile
+            (projectile-darcs-command "${pkgs.darcs}/bin/darcs show files -0 ."))
+          '(rustic
+            (rustic-rustfmt-bin "${pkgs.rustfmt}/bin/rustfmt"))
+          '(sbt-mode
+            (sbt:program-name "${pkgs.sbt}/bin/sbt"))
+          '(treemacs
+            (treemacs-python-executable "${pkgs.python}/bin/python"))
+          '(vc-pijul
+            (vc-pijul-program-name "${pkgs.pijul}/bin/pijul")))
 
-      ;; TODO: These variables don’t work if set via a theme. See
-      ;;       jwiegley/use-package#1002. Unfortunately, this means they get
-      ;;       written out to custom.el, and then that ends up with the wrong
-      ;;       values over time.
-      (custom-set-variables
-       ;; easy-pg
-       '(epg-gpg-program "${pkgs.gnupg}/bin/gpg2")
-       '(epg-gpgconf-program "${pkgs.gnupg}/bin/gpgconf")
-       '(epg-gpgsm-program "${pkgs.gnupg}/bin/gpgsm"))
+        ;; TODO: These variables don’t work if set via a theme. See
+        ;;       jwiegley/use-package#1002. Unfortunately, this means they get
+        ;;       written out to custom.el, and then that ends up with the wrong
+        ;;       values over time.
+        (custom-set-variables
+         ;; easy-pg
+         '(epg-gpg-program "${pkgs.gnupg}/bin/gpg2")
+         '(epg-gpgconf-program "${pkgs.gnupg}/bin/gpgconf")
+         '(epg-gpgsm-program "${pkgs.gnupg}/bin/gpgsm"))
 
-      ;; These are personal settings that should remain after everything else is
-      ;; upstreamed.
-      (custom-pseudo-theme-set-variables 'sellout-system-configurations
-        ;; Emacs packages
+        ;; These are personal settings that should remain after everything else is
+        ;; upstreamed.
+        (custom-pseudo-theme-set-variables 'sellout-system-configurations
+          ;; Emacs packages
 
-        ;; no package
-        '(user-full-name
-          "${config.lib.local.primaryEmailAccount.realName}")
-        '(user-mail-address
-          "${config.lib.local.primaryEmailAccount.address}")
-        ;; org
-        '(org-default-notes-file "${config.xdg.userDirs.documents}/org/notes.org")
-        '(org-directory "${config.xdg.userDirs.documents}/org")
-        ;; tramp
-        ;; NB: This one should _not_ be upstreamed, because the default is nil.
-        '(tramp-auto-save-directory "${emacs-state-home}/tramp/auto-save/")
-        ;; NB: Set here instead of in init.el because it depends on home-manager.
-        '(tramp-use-ssh-controlmaster-options
-          nil
-          nil
-          ()
-          "ControlMaster options are set by home-manager.")
-        ;; url
-        ;; TODO: Do I actually want to set this?
-        ;;'(url-personal-mail-address
-        ;;  "${config.lib.local.primaryEmailAccount.address}")
+          ;; no package
+          '(user-full-name
+            "${config.lib.local.primaryEmailAccount.realName}")
+          '(user-mail-address
+            "${config.lib.local.primaryEmailAccount.address}")
+          ;; org
+          '(org-default-notes-file "${config.xdg.userDirs.documents}/org/notes.org")
+          '(org-directory "${config.xdg.userDirs.documents}/org")
+          ;; tramp
+          ;; NB: This one should _not_ be upstreamed, because the default is nil.
+          '(tramp-auto-save-directory "${emacs-state-home}/tramp/auto-save/")
+          ;; NB: Set here instead of in default.el because it depends on home-manager.
+          '(tramp-use-ssh-controlmaster-options
+            nil
+            nil
+            ()
+            "ControlMaster options are set by home-manager.")
+          ;; url
+          ;; TODO: Do I actually want to set this?
+          ;;'(url-personal-mail-address
+          ;;  "${config.lib.local.primaryEmailAccount.address}")
 
-        ;; third-party packages
+          ;; third-party packages
 
-        ;; flim
-        '(smtp-fqdn "${config.lib.local.primaryEmailAccount.smtp.host}")
-        ;; magit
-        '(magit-repository-directories
-          ;; TODO: Add entries for rest of tailnet.
-          '(("${config.lib.local.xdg.userDirs.projects.home}" . 3)))
-        ;; projectile
-        '(projectile-dirconfig-file
-          "${config.lib.local.xdg.config.rel}/projectile")
-        ;; wanderlust
-        '(elmo-imap4-default-port
-          ${toString config.lib.local.primaryEmailAccount.smtp.port})
-        '(elmo-imap4-default-server
-          "${config.lib.local.primaryEmailAccount.imap.host}")
-        '(elmo-imap4-default-user
-          "${config.lib.local.primaryEmailAccount.userName}")
-        '(wl-smtp-posting-port
-          ${toString config.lib.local.primaryEmailAccount.smtp.port})
-        '(wl-smtp-posting-server
-          "${config.lib.local.primaryEmailAccount.smtp.host}")
-        '(wl-smtp-posting-user
-          "${config.lib.local.primaryEmailAccount.userName}"))
+          ;; flim
+          '(smtp-fqdn "${config.lib.local.primaryEmailAccount.smtp.host}")
+          ;; magit
+          '(magit-repository-directories
+            ;; TODO: Add entries for rest of tailnet.
+            '(("${config.lib.local.xdg.userDirs.projects.home}" . 3)))
+          ;; projectile
+          '(projectile-dirconfig-file
+            "${config.lib.local.xdg.config.rel}/projectile")
+          ;; wanderlust
+          '(elmo-imap4-default-port
+            ${toString config.lib.local.primaryEmailAccount.smtp.port})
+          '(elmo-imap4-default-server
+            "${config.lib.local.primaryEmailAccount.imap.host}")
+          '(elmo-imap4-default-user
+            "${config.lib.local.primaryEmailAccount.userName}")
+          '(wl-smtp-posting-port
+            ${toString config.lib.local.primaryEmailAccount.smtp.port})
+          '(wl-smtp-posting-server
+            "${config.lib.local.primaryEmailAccount.smtp.host}")
+          '(wl-smtp-posting-user
+            "${config.lib.local.primaryEmailAccount.userName}"))
 
-      (custom-pseudo-theme-set-local-variables 'sellout-system-configurations
-        ;; Emacs packages
-        '(autorevert
-          ;; TODO: This doesn’t depend on Nix, but it does require ‘c-p-t-s-l-v’.
-          ;;       Those functions should be moved into their own module (package?)
-          ;;       so they can easily be referenced from init.el as well.
-          (auto-revert-check-vc-info
-           t
-           nil
-           ()
-           "This doesn’t behave well with TRAMP (see magit/magit#1205), so leave it disabled on remote machines.")))
+        (custom-pseudo-theme-set-local-variables 'sellout-system-configurations
+          ;; Emacs packages
+          '(autorevert
+            ;; TODO: This doesn’t depend on Nix, but it does require ‘c-p-t-s-l-v’.
+            ;;       Those functions should be moved into their own module (package?)
+            ;;       so they can easily be referenced from default.el as well.
+            (auto-revert-check-vc-info
+             t
+             nil
+             ()
+             "This doesn’t behave well with TRAMP (see magit/magit#1205), so leave it disabled on remote machines.")))
 
-      (custom-pseudo-theme-set-faces 'sellout-system-configurations
-        '(default
-          ((t (:family "${config.lib.local.defaultSansFont}"
-               :height
-               ${builtins.toString (builtins.floor (config.lib.local.defaultFontSize * 10))}))))
-        '(fixed-pitch ((t (:family "${config.lib.local.defaultMonoFont}"))))
-        '(font-lock ((t (:family "${config.lib.local.programmingFont}"))))
-        '(variable-pitch ((t (:family "${config.lib.local.defaultSansFont}")))))
-    '';
+        (custom-pseudo-theme-set-faces 'sellout-system-configurations
+          '(default
+            ((t (:family "${config.lib.local.defaultSansFont}"
+                 :height
+                 ${builtins.toString (builtins.floor (config.lib.local.defaultFontSize * 10))}))))
+          '(fixed-pitch ((t (:family "${config.lib.local.defaultMonoFont}"))))
+          '(font-lock ((t (:family "${config.lib.local.programmingFont}"))))
+          '(variable-pitch ((t (:family "${config.lib.local.defaultSansFont}")))))
+      ''
+      + builtins.readFile ./default.el;
     extraPackages = epkgs: [
       epkgs.ace-window # better `other-window`
       # epkgs.agda2-mode # fails while linking Agda-2.6.2.2

--- a/nix/modules/emacs/user-directory/init.el
+++ b/nix/modules/emacs/user-directory/init.el
@@ -1,0 +1,23 @@
+;;; init.el --- Marker for ‘user-emacs-directory’  -*- lexical-binding: t -*-
+
+;;; Commentary:
+
+;; This file needs to exist so that Emacs knows what directory to treat as
+;; ‘user-emacs-directory’, but the bulk of the configuration is managed via a
+;; Nix module.
+
+;; Local (non-Nix-managed) configuration can be set in ./custom.el, using the
+;; Customize system, or manually in ./local.el. ./local.el gets ‘require’d, so
+;; make sure it ends with (publish 'local). This file doesn’t need to exist if
+;; you have no local configuration. It also gets loaded early (but after
+;; Nix-dependent setup and ‘use-package’) so that it can affect other things in
+;; the Nix-managed config. It can delay various things by using ‘use-package’’s
+;; :after.
+
+;;; Code:
+
+(custom-set-variables
+ ;; NB: If this isn’t set in _this_ file, Emacs will ignore it by design.
+ '(inhibit-startup-screen t nil () "Explicitly set in ‘user-init-file’."))
+
+;;; init.el ends here


### PR DESCRIPTION
- add an init.el to user-directory (helps ensure `user-emacs-directory` is set correctly)
- move `inhibit-startup-screen` to init.el (the only place it works)
- try to load a local.el from `user-emacs-directory` (for temporary config)
- rename (and remember to include) the module’s primary .el file