### PR TITLE
Change the `sys` entry in the flake registry

### DIFF
--- a/nix/modules/home-configuration.nix
+++ b/nix/modules/home-configuration.nix
@@ -4,7 +4,6 @@
   dotfiles,
   lib,
   pkgs,
-  self,
   ...
 }: {
   imports = [
@@ -503,7 +502,6 @@
     ##       overridden when Home Manager is used as a module. This is a
     ##       workaround until nix-community/home-manager#5870 is resolved.
     package = lib.mkDefault pkgs.nix;
-    registry.sys.flake = self;
     settings = {
       ## TODO: was required for Nix on Mac at some point -- review
       allow-symlinked-store = pkgs.stdenv.hostPlatform.isDarwin;

--- a/nix/modules/nix-configuration.nix
+++ b/nix/modules/nix-configuration.nix
@@ -1,13 +1,18 @@
 {
   config,
+  flaky,
   lib,
   nixpkgs,
   pkgs,
   ...
 }: {
   nix = {
-    ## Set the registry’s Nixpkgs to match this flake’s.
-    registry.nixpkgs.flake = nixpkgs;
+    registry = {
+      ## Set the registry’s Nixpkgs to match this flake’s.
+      nixpkgs.flake = nixpkgs;
+      ## Allows `sys#` to reference the templates, devShells, etc. from Flaky.
+      sys.flake = flaky;
+    };
 
     settings = {
       ## This causes builds to optimize after themselves, incrementally.


### PR DESCRIPTION
- have it point to Flaky instead of to whatever downstream flake defines the config
- set it in every configuration, not just home configurations