### PR TITLE
Make it possible to locally allow unfree apps

### DIFF
--- a/nix/modules/home-configuration.nix
+++ b/nix/modules/home-configuration.nix
@@ -492,6 +492,17 @@
     '';
   };
 
+  local.nixpkgs = {
+    enable = true;
+    allowedUnfreePackages = [
+      "1password-cli"
+      "eagle"
+      "onepassword-password-manager"
+      "plexmediaserver"
+      "zoom"
+    ];
+  };
+
   manual.html.enable = true;
 
   news.display = "show";

--- a/nix/modules/nixos-configuration.nix
+++ b/nix/modules/nixos-configuration.nix
@@ -80,6 +80,15 @@
     supportedLocales = ["all"]; # How big can these things be?
   };
 
+  local.nixpkgs = {
+    enable = true;
+    allowedUnfreePackages = [
+      "steam"
+      "steam-original"
+      "steam-run"
+    ];
+  };
+
   ## Auto-adjust system time.
   location.provider = "geoclue2";
   services = {

--- a/nix/modules/nixpkgs-configuration.nix
+++ b/nix/modules/nixpkgs-configuration.nix
@@ -1,15 +1,23 @@
-{lib, ...}: {
-  nixpkgs.config.allowUnfreePredicate = pkg:
-    builtins.elem (lib.getName pkg) [
-      "1password"
-      "1password-cli"
-      "eagle"
-      "onepassword-password-manager"
-      "plexmediaserver"
-      "steam"
-      "steam-original"
-      "steam-run"
-      "vscode-extension-ms-vsliveshare-vsliveshare"
-      "zoom"
-    ];
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.local.nixpkgs;
+in {
+  options.local.nixpkgs = {
+    enable = lib.mkEnableOption "Local Nixpkgs settings";
+
+    allowedUnfreePackages = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = ''
+        A list of package names that have been approved for unfree usage.
+      '';
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    nixpkgs.config.allowUnfreePredicate = pkg:
+      builtins.elem (lib.getName pkg) cfg.allowedUnfreePackages;
+  };
 }


### PR DESCRIPTION
Because `allowUnfreePredicate` is a function, it can’t be merged. This adds a `local.nixpkgs.allowUnfreePackages` option that can be add to from anywhere, making it possible to allow unfree packages in the places they are added to a config.