### PR TITLE
Update Bradix (and other) flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,11 +130,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729757100,
-        "narHash": "sha256-x+8uGaX66V5+fUBHY23Q/OQyibQ38nISzxgj7A7Jqds=",
+        "lastModified": 1729826725,
+        "narHash": "sha256-w3WNlYxqWYsuzm/jgFPyhncduoDNjot28aC8j39TW0U=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "04193f188e4144d7047f83ad1de81d6034d175cd",
+        "rev": "7840909b00fbd5a183008a6eb251ea307fe4a76e",
         "type": "github"
       },
       "original": {
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729731358,
-        "narHash": "sha256-J7xuHpaXohmi+8swVo2CC2udHnRSR3aHWFwvx/0e9tM=",
+        "lastModified": 1729817804,
+        "narHash": "sha256-+Tq5dXHHorj89Sfp3DFCTDOlrzfHSa6dTQ3fzhRtKSU=",
         "owner": "bandithedoge",
         "repo": "nixpkgs-firefox-darwin",
-        "rev": "219eb7b2e26efc167ad431e276a23484e553d01d",
+        "rev": "190fe36b4548221f5f8a40cf883216ad93e48084",
         "type": "github"
       },
       "original": {
@@ -349,11 +349,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1729632480,
-        "narHash": "sha256-S7ytfL9xz8LCAhtDjX9qoDkcQnYqqy6/hQLnEW9JZjA=",
+        "lastModified": 1729790966,
+        "narHash": "sha256-/6KrmkPuMJzOBiK4nfq+m1zBhhtsq/XBq+URMiRrS0k=",
         "owner": "sellout",
         "repo": "flaky",
-        "rev": "cc53a2f64611aaee9770438e651d45dcc6649508",
+        "rev": "b3cab5a4227f1f8a182e5352069fa8f8a9874394",
         "type": "github"
       },
       "original": {
@@ -426,11 +426,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729719555,
-        "narHash": "sha256-+QUZUJOe3w00SSXPSkydbQwoHriDonkuaTHGbPaDE68=",
+        "lastModified": 1729805997,
+        "narHash": "sha256-w8pVk/gHfK1FOejZAp5qFFXsYqGWfxaDYsjsh0sLomI=",
         "owner": "jacekszymanski",
         "repo": "nixcasks",
-        "rev": "299fc126a349790a7bfc6199e0a5d4dc5628d734",
+        "rev": "dc2d0fa5c24154e39ec6b816d04b7420efaeac2d",
         "type": "github"
       },
       "original": {
@@ -441,11 +441,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729530158,
-        "narHash": "sha256-rprj2S6w8RjDyNPnHbb2HIgE8lnbfic8L1YbUURJRYU=",
+        "lastModified": 1729661998,
+        "narHash": "sha256-Ano6IvS0/jEoeaYgdWo/kGBG1rwYslJ/ld6hCbbzQo0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a3f90277d366596f8fdac8d9608d2471e204a77a",
+        "rev": "e303588c321c2b61da72e1d4675d1c1e4a437d2d",
         "type": "github"
       },
       "original": {
@@ -521,11 +521,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1729788406,
-        "narHash": "sha256-qLeBo7fvq56YbgHMgV+n8p284WlDoGI5jF8Jnq45+N8=",
+        "lastModified": 1729874852,
+        "narHash": "sha256-ngJHU3jXU7pSSyG0diRIotgnLf2us6XR/jBSlYGD1hU=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "9ffdd336415bc60c0a3341f981d735ab8ef14f95",
+        "rev": "e39356f189144007b6ff29a82429c6486c59a034",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -102,14 +102,19 @@
           "bradix",
           "flaky",
           "nixpkgs"
+        ],
+        "systems": [
+          "bradix",
+          "flaky",
+          "systems"
         ]
       },
       "locked": {
-        "lastModified": 1727152774,
-        "narHash": "sha256-gl22QhlVo85J8q3i+LkzjrnuzhbWF30XN0G0s5P5dmk=",
+        "lastModified": 1729884344,
+        "narHash": "sha256-5UDT6oFovUqEIiyHe3tsLsVjjEmz7bJYyvO9M/e9TXU=",
         "owner": "sellout",
         "repo": "bradix",
-        "rev": "bd1b2cb6b4b47012cd74665faa94fc3f911edb4a",
+        "rev": "367efd3bcff767856f03c42f4f74f3684a053af1",
         "type": "github"
       },
       "original": {
@@ -158,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722525569,
-        "narHash": "sha256-ZDMttQMIMwTiZKpQbTWCZKEnoXdvSq8P/jhiMDDPvB8=",
+        "lastModified": 1725603962,
+        "narHash": "sha256-dF+B1ueCHcL0K3oz07sxa6WxsLl8jLpRrjiDGEnI450=",
         "owner": "sellout",
         "repo": "elisp-reader.el",
-        "rev": "875fa64a4c079c6f1938e90517c8b33aa6f7ebac",
+        "rev": "fb567d91c420da5c3bc3ee6981111ffa03e208dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The previous version had a bad reference to elisp-reader that somehow slipped through.