### PR TITLE
Some more homeConfiguration improvements

### DIFF
--- a/nix/modules/home-configuration.nix
+++ b/nix/modules/home-configuration.nix
@@ -32,6 +32,11 @@
 
   home = {
     activation = {
+      ## TODO: Should move a version of this to Home Manager itself.
+      setUpErrorTrap = lib.hm.dag.entryBefore ["checkLaunchAgents"] ''
+        trap '_iError "Home Manager activation failed with $? at $(basename $0):$LINENO"; exit 1' ERR
+      '';
+
       # TODO: This should be removed once
       #       https://github.com/nix-community/home-manager/issues/1341 is
       #       closed.

--- a/nix/modules/home-configuration.nix
+++ b/nix/modules/home-configuration.nix
@@ -371,8 +371,8 @@
       # TODO: Since this uses both `nix` and the containing flake, it seems like
       #       there should be a better way to get that information to the
       #       command than having the shell look it up.
-      devEnv = devShell: "nix develop " + "sys#" + devShell;
-      template = template: "nix flake init -t " + "sys#" + template;
+      devEnv = devShell: "nix develop " + "env#" + devShell;
+      template = template: "nix flake init -t " + "env#" + template;
     in {
       grep = "grep --color";
 

--- a/nix/modules/locale.nix
+++ b/nix/modules/locale.nix
@@ -21,7 +21,8 @@
       "3" = "EEE, MMM d, y";
       "4" = "EEEE, MMMM d, y";
     };
-    AppleICUForce24HourTime = 1;
+    AppleICUForce12HourTime = false;
+    AppleICUForce24HourTime = true;
     AppleLanguages = ["en"];
     AppleLocale = "en_US";
     AppleMeasurementUnits = "Centimeters";

--- a/nix/modules/nix-configuration.nix
+++ b/nix/modules/nix-configuration.nix
@@ -1,6 +1,4 @@
 {
-  config,
-  flaky,
   lib,
   nixpkgs,
   pkgs,
@@ -10,8 +8,13 @@
     registry = {
       ## Set the registry’s Nixpkgs to match this flake’s.
       nixpkgs.flake = nixpkgs;
-      ## Allows `sys#` to reference the templates, devShells, etc. from Flaky.
-      sys.flake = flaky;
+      ## Allows `sys#` to reference the templates, devShells, etc. from Flaky
+      ## environments.
+      env.to = {
+        type = "github";
+        owner = "sellout";
+        repo = "flaky-environments";
+      };
     };
 
     settings = {


### PR DESCRIPTION
- report errors in HM activation
- stop switching Macs to 12-hour mode on HM activation
- reference Flaky environments instead of Flaky from the registry