### PR TITLE
Slightly improve the NixOS time zone situation

### DIFF
--- a/nix/modules/date-time.nix
+++ b/nix/modules/date-time.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  pkgs,
+  ...
+}: {
+  ## Auto-adjust system time.
+  ## See NixOS/nixpkgs#68489 for the current mess of this situation.
+  location.provider = "geoclue2";
+  services.automatic-timezoned.enable = true;
+  services.geoclue2 = {
+    enable = true; # This is ostensibly redundant with `location.provider`.
+    enableDemoAgent = lib.mkForce true;
+    geoProviderUrl = "https://beacondb.net/v1/geolocate";
+  };
+
+  ## Since the automatic time-zone setting doesn’t seem to be working, this
+  ## allows `tzupdate` to bring the time zone in sync with the current location.
+  ## See NixOS/nixpkgs#127984 for more context.
+  environment.shellAliases.tzupdate = "timedatectl set-timezone $(${lib.getExe pkgs.tzupdate} --print-only)";
+  time.timeZone = null;
+}

--- a/nix/modules/nixos-configuration.nix
+++ b/nix/modules/nixos-configuration.nix
@@ -8,6 +8,7 @@
 }: {
   imports = [
     agenix.nixosModules.age
+    ./date-time.nix
     ./games.nix
     ./input-devices.nix
     ./locale.nix
@@ -71,14 +72,6 @@
   hardware = {
     bluetooth.enable = true;
     pulseaudio.enable = false;
-  };
-
-  ## Auto-adjust system time.
-  location.provider = "geoclue2";
-  services = {
-    automatic-timezoned.enable = true;
-    ## To work around NixOS/nixpkgs#68489
-    geoclue2.enableDemoAgent = lib.mkForce true;
   };
 
   networking = {


### PR DESCRIPTION
This updates the non-working automatic tz updating a bit, but also adds settings
so that running `tzupdate` will at least manually sync to the correct time zone.