### PR TITLE
Add PowerPhotos

### DIFF
--- a/nix/modules/darwin-configuration.nix
+++ b/nix/modules/darwin-configuration.nix
@@ -103,6 +103,7 @@
       # "delicious-library" # perhaps removed?
       "eagle" # doesn't respect appdir # not available on darwin via Nix
       "google-drive" # doesn't respect appdir
+      "powerphotos"
       "psi"
       "r" # doesn't respect appdir
       "racket"


### PR DESCRIPTION
Apple’s Photos app is pretty limited, and this adds some useful features while still integrating with the Apple photo library.