### PR TITLE
More updates

### DIFF
--- a/nix/modules/darwin-configuration.nix
+++ b/nix/modules/darwin-configuration.nix
@@ -224,4 +224,6 @@
   ## doesn’t manage the OS.
   system.defaults.CustomSystemPreferences."com.apple.commerce".AutoUpdateRestartRequired = true;
   system.defaults.SoftwareUpdate.AutomaticallyInstallMacOSUpdates = true;
+
+  system.startup.chime = false;
 }

--- a/nix/modules/date-time.nix
+++ b/nix/modules/date-time.nix
@@ -16,6 +16,9 @@
   ## Since the automatic time-zone setting doesn’t seem to be working, this
   ## allows `tzupdate` to bring the time zone in sync with the current location.
   ## See NixOS/nixpkgs#127984 for more context.
-  environment.shellAliases.tzupdate = "timedatectl set-timezone $(${lib.getExe pkgs.tzupdate} --print-only)";
+  services.tzupdate = {
+    enable = true;
+    timer.enable = true;
+  };
   time.timeZone = null;
 }

--- a/nix/modules/firefox.nix
+++ b/nix/modules/firefox.nix
@@ -5,7 +5,11 @@
   ...
 }: let
   ## These are defined in https://mozilla.github.io/policy-templates/.
-  policies.DisableAppUpdate = true;
+  policies = {
+    DisableAppUpdate = true;
+    # See https://mastodon.social/@mcc/114869357468477091
+    DisableFirefoxStudies = true;
+  };
 in {
   programs.firefox = {
     inherit policies;
@@ -43,9 +47,17 @@ in {
         defaultFont = config.lib.local.defaultFont;
       in {
         "browser.aboutConfig.showWarning" = false;
+        "browser.display.use_system_colors" = true;
         "browser.contentblocking.category" = "strict";
-        ## Disable AI chat
+        ## Disable AI features
         "browser.ml.chat.enabled" = false;
+        "browser.ml.chat.shortcuts" = false;
+        "browser.ml.chat.shortcuts.custom" = false;
+        "browser.ml.chat.sidebar" = false;
+        "browser.ml.enable" = false;
+        "browser.tabs.groups.smart.enabled" = false;
+        "browser.tabs.groups.smart.optin" = false;
+        "browser.tabs.groups.smart.userEnabled" = false;
         ## Disable ads for Mozilla products
         "browser.preferences.moreFromMozilla" = false;
         "browser.startup.homepage" = "https://github.com/pulls/review-requested";
@@ -53,6 +65,7 @@ in {
         "browser.urlbar.suggest.quicksuggest.sponsored" = false;
         ## Automatically enable newly-installed extensions.
         "extensions.autoDisableScopes" = 0;
+        ## fonts
         "font.default.x-unicode" = "sans-serif";
         "font.default.x-western" = "sans-serif";
         "font.name.monospace.x-unicode" = defaultFont.monoFamily;
@@ -63,9 +76,13 @@ in {
         "font.size.monospace.x-western" = defaultFont.size;
         "font.size.variable.x-unicode" = defaultFont.size;
         "font.size.variable.x-western" = builtins.floor defaultFont.size;
+        ## printing
+        "print.prefer_system_dialog" = true;
+        ## privacy
         "privacy.globalprivacycontrol.enabled" = true;
         "privacy.globalprivacycontrol.functionality.enabled" = true;
         "privacy.globalprivacycontrol.pbmode.enabled" = true;
+        ## Mozilla Sync account
         "services.sync.username" =
           config.lib.local.primaryEmailAccount.address;
       };

--- a/nix/modules/home-configuration.nix
+++ b/nix/modules/home-configuration.nix
@@ -351,8 +351,10 @@
     enable = true;
     dictionaries = {
       en = [
+        "affine"
         "arity"
         "boulderers"
+        "bugfix"
         "coroplast"
         "cortado"
         "coöperating"
@@ -365,12 +367,15 @@
         "dozenal"
         "duoid"
         "duoids"
+        "formatter"
         "freedive"
         "freediving"
+        "intricacies"
         "kell"
         "kells"
         "palantir"
         "parametricity"
+        "pessimize"
         "tenkara"
         "topo"
       ];
@@ -667,6 +672,8 @@
       frequency = "daily";
     };
 
+    ## NB: On a new user account, it’s important to run `keybase login` to avoid
+    ##   > ▶ [WARN keybase kbfs_pin_tlfs.go:161] 062 TLF Pin operation failed: Login required: no sessionArgs available since no login path worked [tags:PIN=IMq0lVNJdY1P]
     keybase.enable = pkgs.stdenv.hostPlatform.isLinux;
 
     ## notification daemon for Wayland

--- a/nix/modules/home-configuration.nix
+++ b/nix/modules/home-configuration.nix
@@ -667,9 +667,21 @@
   };
 
   services = {
-    home-manager.autoUpgrade = {
-      enable = pkgs.stdenv.hostPlatform.isLinux;
-      frequency = "daily";
+    home-manager = {
+      ## This helps keep the size of the Nix store down by periodically expiring
+      ## old generations then running `nix-collect-garbage`.
+      autoExpire = {
+        # Can change this to `true` once
+        # https://github.com/nix-community/home-manager/commit/20974416338898f0725a87832e4cd9bd82cbdaad
+        # is on the version of Home Manager we use (probably 25.11).
+        enable = pkgs.stdenv.hostPlatform.isLinux;
+        frequency = "weekly";
+        store.cleanup = true;
+      };
+      autoUpgrade = {
+        enable = pkgs.stdenv.hostPlatform.isLinux;
+        frequency = "daily";
+      };
     };
 
     ## NB: On a new user account, it’s important to run `keybase login` to avoid

--- a/nix/modules/home-configuration.nix
+++ b/nix/modules/home-configuration.nix
@@ -152,9 +152,9 @@
     ## • the package has its own GUI that we prefer over any Emacs interface.
     packages = let
       ## For packages that should be gotten from nixcasks on darwin. The second
-      ## argument may be null, but if the nixcast package name differs from the
+      ## argument may be null, but if the nixcasks package name differs from the
       ## Nixpkgs name, then it needs to be set.
-      maybeNixcask = pkg: nixcastPkg:
+      maybeCask = pkg: nixcastPkg:
         if pkgs.stdenv.hostPlatform.isDarwin
         then let
           realNixcastPkg =
@@ -169,13 +169,13 @@
         pkgs.age
         pkgs.agenix
         ## doesn’t contain darwin GUI
-        (maybeNixcask "anki" null)
+        (maybeCask "anki" null)
         pkgs.awscli
         pkgs.bash-strict-mode
         ## marked broken on darwin
-        (maybeNixcask "calibre" null)
+        (maybeCask "calibre" null)
         ## DOS game emulator # fails to build on darwin # x86 game emulator
-        (maybeNixcask "dosbox" null)
+        (maybeCask "dosbox" null)
         # pkgs.discord # currently subsumed by ferdium
         # pkgs.element-desktop # currently subsumed by ferdium
         pkgs.ghostscript
@@ -185,9 +185,9 @@
         pkgs.jekyll
         pkgs.magic-wormhole
         ## not available on darwin via Nix
-        (maybeNixcask "mumble" null)
+        (maybeCask "mumble" null)
         ## not available on darwin via Nix
-        (maybeNixcask "obs-studio" "obs")
+        (maybeCask "obs-studio" "obs")
         pkgs.python3Packages.opentype-feature-freezer
         # pkgs.slack # currently subsumed by ferdium
         pkgs.synergy
@@ -197,7 +197,7 @@
         pkgs.xdg-ninja # home directory complaining
       ]
       ++ lib.optionals (pkgs.system != "aarch64-linux") [
-        (maybeNixcask "simplex-chat-desktop" "simplex")
+        (maybeCask "simplex-chat-desktop" "simplex")
         pkgs.spotify
         pkgs.unison-ucm # Unison dev tooling
         pkgs.zoom-us

--- a/nix/modules/nix-configuration.nix
+++ b/nix/modules/nix-configuration.nix
@@ -7,7 +7,12 @@
   nixpkgs-unstable,
   pkgs,
   ...
-}: {
+}: let
+  ## We pull the preferred Cachix information from the Nix CI configuration.
+  ## TODO: We should be able to get this from the project configuration that
+  ##       generates this file.
+  cachix = (import ../../nix-ci.nix).cachix;
+in {
   nix = {
     registry = {
       ## Set the registry’s Nixpkgs to match this flake’s.
@@ -51,10 +56,8 @@
         "flakes"
         "nix-command"
       ];
-      extra-trusted-public-keys = [
-        "sellout.cachix.org-1:v37cTpWBEycnYxSPAgSQ57Wiqd3wjljni2aC0Xry1DE="
-      ];
-      extra-trusted-substituters = ["https://sellout.cachix.org"];
+      extra-trusted-public-keys = [cachix.public-key];
+      extra-trusted-substituters = ["https://${cachix.name}.cachix.org"];
       ## NIX_PATH is still used by many useful tools, so we set it to the same
       ## value as the one used by this flake. For more information, see
       ## https://nixos-and-flakes.thiscute.world/best-practices/nix-path-and-flake-registry

--- a/nix/modules/programming/envrc
+++ b/nix/modules/programming/envrc
@@ -1,3 +1,5 @@
+### -*- mode: shell-script; -*-
+
 direnv_layout_dir="$PWD/.cache/direnv"
 
 if type -P lorri &>/dev/null; then

--- a/nix/modules/system-configuration.nix
+++ b/nix/modules/system-configuration.nix
@@ -22,11 +22,6 @@
   environment = {
     extraOutputsToInstall = ["devdoc" "doc" "man"];
     systemPackages = [
-      ## Nix
-      pkgs.home-manager
-      pkgs.nix-du
-      pkgs.nox
-      ## system
       pkgs.cacert
       pkgs.coreutils
       pkgs.gnupg


### PR DESCRIPTION
- Get Cachix information from the Nix CI configuration.
- A bunch of Firefox config, mostly disabling AI.
- Disable the macOS startup chime.
- Some Emacs improvements:
  - move `flyspell-correct-word` to right-click,
  - fix Cabal comment syntax highlighting,
  - enable format-on-save in Eglot, and
  - set up Project Manager as the formatter for the Nix language server.
- Enable syntax highlighting for the envrc file.
- Move Nix tooling to nix-configuration.nix.
- Rename `maybeNixcask` to `maybeCask`.
- Add a few words to the dictionary.
- Auto-update time zone on NixOS.
- Enable Home Manager’s autoExpire service.