### PR TITLE
Config improvements

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -834,26 +834,6 @@
         "type": "github"
       }
     },
-    "mkalias": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1678761502,
-        "narHash": "sha256-tL3C/b2BPOGQpV287wECDCDWmKwwPvezAAN3qz7N07M=",
-        "owner": "reckenrode",
-        "repo": "mkalias",
-        "rev": "8a5478cdb646f137ebc53cb9d235f8e5892ea00a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "reckenrode",
-        "repo": "mkalias",
-        "type": "github"
-      }
-    },
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
@@ -1362,7 +1342,6 @@
           "flaky",
           "home-manager"
         ],
-        "mkalias": "mkalias",
         "nix-math": "nix-math",
         "nixcasks": "nixcasks",
         "nixpkgs": [

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,6 @@
     flake-utils,
     flaky,
     home-manager,
-    mkalias,
     nix-math,
     nixcasks,
     nixpkgs,
@@ -112,7 +111,6 @@
           inherit
             flake-utils
             home-manager
-            mkalias
             nixpkgs
             nixpkgs-master
             ;
@@ -315,12 +313,6 @@
     flake-parts = {
       inputs.nixpkgs-lib.follows = "nixpkgs";
       url = "github:hercules-ci/flake-parts";
-    };
-
-    ## Avoids the need to give `Finder` access to make aliases on MacOS.
-    mkalias = {
-      inputs.nixpkgs.follows = "nixpkgs";
-      url = "github:reckenrode/mkalias";
     };
 
     nix-math = {

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,9 @@
   description = "Sellout’s general configuration";
 
   nixConfig = {
+    ## NB: This is a consequence of using `self.pkgsLib.runEmptyCommand`, which
+    ##     allows us to sandbox derivations that otherwise can’t be.
+    allow-import-from-derivation = true;
     ## https://github.com/NixOS/rfcs/blob/master/rfcs/0045-deprecate-url-syntax.md
     extra-experimental-features = ["no-url-literals"];
     extra-substituters = [

--- a/nix/modules/darwin/default.nix
+++ b/nix/modules/darwin/default.nix
@@ -194,10 +194,6 @@
 
   security.pam.services.sudo_local.touchIdAuth = true;
 
-  ## TODO: Remove this (from nix-darwin, too) once tailscale/tailscale#8436 is
-  ##       fixed.
-  services.tailscale.overrideLocalDns = true;
-
   ## For any of this to work, we need to enable automatic updates in general.
   system.defaults.CustomSystemPreferences."com.apple.SoftwareUpdate".AutomaticCheckEnabled = true;
   ## This will automatically install macOS updates, which we want because Nix

--- a/nix/modules/firefox.nix
+++ b/nix/modules/firefox.nix
@@ -42,7 +42,44 @@ in {
         ## Disabled
         foxytab
       ];
-      # search.default = "DuckDuckGo";
+      search = {
+        default = "ddg";
+        engines = {
+          nix-packages = {
+            name = "Nix Packages";
+            urls = [
+              {
+                template = "https://search.nixos.org/packages";
+                params = [
+                  {
+                    name = "type";
+                    value = "packages";
+                  }
+                  {
+                    name = "query";
+                    value = "{searchTerms}";
+                  }
+                ];
+              }
+            ];
+
+            icon = "${pkgs.nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake.svg";
+            definedAliases = ["@np"];
+          };
+
+          amazon.metaData.alias = "@amazon";
+          bing.metaData.hidden = true;
+          ebay.metaData.hidden = true;
+          google.metaData = {
+            alias = "@google";
+            hidden = true;
+          };
+          wikipedia.metaData.alias = "@wikipedia";
+        };
+        force = true;
+        order = ["ddg" "wikipedia" "nw" "np" "amazon"];
+      };
+      ## You can explore the settings at the URL `about:config` in Firefox.
       settings = let
         defaultFont = config.lib.local.defaultFont;
       in {

--- a/nix/modules/home-configuration.nix
+++ b/nix/modules/home-configuration.nix
@@ -27,6 +27,7 @@
     ./tex.nix
     ./vcs
     ./wakatime.nix
+    ./xdg.nix
   ];
 
   accounts = {
@@ -452,31 +453,6 @@
       };
     };
 
-    # Variables that `config.xdg` doesn’t provide, but that I wish it would.
-    xdg = {
-      bin = {
-        home = config.lib.local.addHome config.lib.local.xdg.bin.rel;
-        rel = "${config.lib.local.xdg.local.rel}/bin";
-      };
-      cache.rel = config.lib.local.removeHome config.xdg.cacheHome;
-      config.rel = config.lib.local.removeHome config.xdg.configHome;
-      data.rel = config.lib.local.removeHome config.xdg.dataHome;
-      local = {
-        home = config.lib.local.addHome config.lib.local.xdg.local.rel;
-        rel = lib.removeSuffix "/state" config.lib.local.xdg.state.rel;
-      };
-      state.rel = config.lib.local.removeHome config.xdg.stateHome;
-      # Don’t know why this one isn’t in the `xdg` module.
-      runtimeDir = config.home.sessionVariables.XDG_RUNTIME_DIR;
-      userDirs = {
-        projects = {
-          home =
-            config.lib.local.addHome config.lib.local.xdg.userDirs.projects.rel;
-          rel = "Projects";
-        };
-      };
-    };
-
     /**
       Returns a path relative to `HOME` that points to either the appropriate XDG
       dir or the corresponding darwin-specific location.
@@ -774,17 +750,6 @@
       "org.hammerspoon.Hammerspoon".MJConfigFile = "${config.xdg.configHome}/hammerspoon/init.lua";
     };
     search = "DuckDuckGo";
-  };
-
-  xdg = {
-    enable = true;
-    userDirs = {
-      createDirectories = true;
-      enable = pkgs.stdenv.hostPlatform.isLinux;
-      videos =
-        lib.mkIf pkgs.stdenv.hostPlatform.isDarwin
-        (config.lib.local.addHome "Movies");
-    };
   };
 
   xresources.path = "${config.xdg.configHome}/x/resources";

--- a/nix/modules/locale.nix
+++ b/nix/modules/locale.nix
@@ -27,13 +27,13 @@ in {
       targets.darwin.defaults.NSGlobalDomain = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
         AppleFirstWeekday.gregorian = 2; # Monday
         AppleICUDateFormatStrings = {
-          # See
-          # https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
-          # for symbol meanings.
-          "1" = "y-MM-dd"; # Iso
-          "2" = "MMM d, y";
-          "3" = "EEE, MMM d, y";
-          "4" = "EEEE, MMMM d, y";
+          ## See
+          ## https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
+          ## for symbol meanings.
+          "1" = "y-MM-dd"; #         1972-01-27 – ISO 8601
+          "2" = "y MMM d eeeeee"; #  1972 Jan 27, Th
+          "3" = "eee, MMM d, y"; #   Thu, Jan 27, 1972
+          "4" = "eeee, MMMM d, y"; # Thursday, January 27, 1972
         };
         AppleICUForce12HourTime = false;
         AppleICUForce24HourTime = true;

--- a/nix/modules/programming/default.nix
+++ b/nix/modules/programming/default.nix
@@ -152,9 +152,12 @@
       '';
     };
 
-    # I used to store these in `$XDG_DOCUMENTS_DIR`, but that directory is often
-    # synced (like Dropbox, iCloud, etc.), so this is a parallel directory for
-    # things that shouldn’t be synced – like version-controlled directories.
+    ## I used to store these in `DOCUMENTS`, but that directory is often synced
+    ## (like Dropbox, iCloud, etc.), so this is a parallel directory for things
+    ## that shouldn’t be synced – like version-controlled directories.
+    ##
+    ## TODO: Replace with `PROJECTS` once  nix-community/home-manager#7937 is in
+    ##       a release.
     userDirs.extraConfig.XDG_PROJECTS_DIR =
       config.lib.local.xdg.userDirs.projects.home;
   };

--- a/nix/modules/vcs/git/template/hooks/post-checkout
+++ b/nix/modules/vcs/git/template/hooks/post-checkout
@@ -1,21 +1,95 @@
 #!/usr/bin/env bash
-
+## TODO: Report this to ShellCheck – strict-mode.bash is on PATH. ShellCheck
+##       should be able to find it (or can it not because my environment editing
+##       the file is different from the one running it? I don’t think so).
+# shellcheck disable=SC1091
 source strict-mode.bash
 
-## This will attempt to run `project-manager` whenever a branch is checked out.
-## It will also run it when a repo is initially cloned.
+## The arguments provided by Git.
+## https://git-scm.com/docs/githooks#_post_checkout
+previous_HEAD=$1
+new_HEAD=$2
+is_branch_checkout=$3
 
-## TODO: See if we can get this from flaky, or even from Project Manager (if
-##       that starts providing it somehow) rather than duplicating the content.
+## This attempts to set up a Nix environment whenever a branch is checked out
+## (including during intial cloning of a repo). It prefers `project-manager`,
+## but falls back to `direnv`. If the project doesn’t use Nix, it infers a
+## common devShell to use. If `nix` isn’t installed, it exits with a warning.
 
-## TODO: This should also check if `project-manager` _should_ exist, and
-##       if so do some more heroic things, e.g,
-##     • `nix run github:sellout/project-manager -- switch`.
-if command -v nix
-then nix develop .#project-manager --command project-manager switch
-elif command -v project-manager
-then
-    echo >&2 "Couldn’t find ‘project-manager’ in project, so running global installation."
-    project-manager switch
-else echo >&2 "Couldn’t find a ‘project-manager’ to run, so skipping."
+## TODO: See if we can get this script from flaky, or even from Project Manager
+##       (if that starts providing it somehow) rather than duplicating the
+##       content.
+
+function templates-dir() {
+  if command -v xdg-user-dir >/dev/null 2>&1; then
+    xdg-user-dir TEMPLATES
+  else
+    echo >&2 "Wanted to install default .envrc, but ‘xdg-user-dir’ isn’t available to find"
+    echo >&2 "source directory."
+    exit 127
+  fi
+}
+
+function set-up-envrc() {
+  if command -v direnv >/dev/null 2>&1; then
+    if ! [ -e .envrc ]; then
+      ## This installs a `lorri`/`use flake` .envrc
+      envrc_path=${1:-$(templates-dir)/.envrc}
+      if [ -r "$envrc_path" ]; then
+        cp "$envrc_path" ./
+        gitignore=$(git rev-parse --git-path info/exclude)
+        if ! [ -e "$gitignore" ]; then
+          mkdir -p "$(git rev-parse --git-path info)"
+          touch "$gitignore"
+        fi
+        if [ -w "$gitignore" ]; then
+          echo /.envrc >> "$gitignore"
+        else
+          echo >&2 "Couldn’t ignore $envrc_path."
+        fi
+      else
+        echo >&2 "$envrc_path doesn’t exist, so couldn’t set up Direnv."
+        exit 1
+      fi
+    fi
+    direnv allow
+  else
+    echo >&2 "The project doesn’t use Project Manager, and ‘direnv’ isn’t installed, so doing"
+    echo >&2 "nothing."
+  fi
+}
+
+## Only do this if we’re switching branches.
+if [[ $previous_HEAD != "$new_HEAD" && $is_branch_checkout -eq 1 ]]; then
+  if command -v nix >/dev/null 2>&1; then
+    if [ -r flake.nix ]; then
+      if ! nix develop .#project-manager --command project-manager switch 2>/dev/null; then
+        if command -v project-manager >/dev/null 2>&1; then
+          if project-manager switch; then
+            echo >&2 "Couldn’t find ‘project-manager’ in project, so ran global installation."
+          else
+            echo >&2 "‘project-manager’ failed, so using Nix flake-based .envrc."
+            set-up-envrc
+          fi
+        elif [ -r .config/project/default.nix ]; then
+          if nix run github:sellout/project-manager -- switch 2>/dev/null; then
+            echo >&2 "Couldn’t find ‘project-manager’ on system, so used ‘nix run’."
+          else
+            echo >&2 "‘project-manager’ failed, so using Nix flake-based .envrc."
+            set-up-envrc
+          fi
+        else
+          echo >&2 "No ‘project-manager’ found, so using Nix flake-based .envrc."
+          set-up-envrc
+        fi
+      fi
+    else
+      echo >&2 "No flake found, so using non-Nix .envrc."
+      ## TODO: This should be one that refers to flaky-environments … somehow
+      ##       guessing the project type.
+      set-up-envrc "$(xdg-user-dir TEMPLATES)/.envrc"
+    fi
+  else
+    echo >&2 "No ‘nix’ installed, so not setting up an automatic .envrc."
+  fi
 fi

--- a/nix/modules/xdg.nix
+++ b/nix/modules/xdg.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: {
+  ## TODO: Remove once nix-community/home-manager#7937 is in a release.
+  home.packages = [pkgs.xdg-user-dirs];
+
+  ## Variables that `config.xdg` doesn’t provide, but that I wish it would.
+  lib.local.xdg = {
+    bin = {
+      home = config.lib.local.addHome config.lib.local.xdg.bin.rel;
+      rel = "${config.lib.local.xdg.local.rel}/bin";
+    };
+    cache.rel = config.lib.local.removeHome config.xdg.cacheHome;
+    config.rel = config.lib.local.removeHome config.xdg.configHome;
+    data.rel = config.lib.local.removeHome config.xdg.dataHome;
+    local = {
+      home = config.lib.local.addHome config.lib.local.xdg.local.rel;
+      rel = lib.removeSuffix "/state" config.lib.local.xdg.state.rel;
+    };
+    state.rel = config.lib.local.removeHome config.xdg.stateHome;
+    # Don’t know why this one isn’t in the `xdg` module.
+    runtimeDir = config.home.sessionVariables.XDG_RUNTIME_DIR;
+    ## TODO: Would like this to be in ./programming/default.nix, but attrs under
+    ##      `lib` don’t merge nicely.
+    userDirs.projects = {
+      home =
+        config.lib.local.addHome config.lib.local.xdg.userDirs.projects.rel;
+      rel = "Projects";
+    };
+  };
+
+  xdg = {
+    enable = true;
+    userDirs = {
+      ## TODO: Use `true` once  nix-community/home-manager#7937 is in a release.
+      enable = pkgs.stdenv.hostPlatform.isLinux;
+      createDirectories = true;
+      ## TODO: Uncomment once  nix-community/home-manager#7937 is in a release.
+      # setSessionVariables = false;
+      videos =
+        lib.mkIf pkgs.stdenv.hostPlatform.isDarwin
+        (config.lib.local.addHome "Movies");
+    };
+  };
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,7 +1,6 @@
 {
   flake-utils,
   home-manager,
-  mkalias,
   nixpkgs,
   nixpkgs-master,
 }: final: prev: let
@@ -25,8 +24,6 @@ in {
   # karabiner-elements = master.karabiner-elements;
 
   lexica-ultralegible = final.callPackage ./packages/lexica-ultralegible.nix {};
-
-  mkalias = mkalias.packages.${final.system}.mkalias;
 
   ## These tests are failing on aarch64-darwin with Nixpkgs 24.11, so disable
   ## them for now.


### PR DESCRIPTION
- Remove Home Manager application aliasing, because it’s broken on Tahoe. Suffer until something better comes along.
- Install `xdg-user-dirs` everywhere.
- Fix Firefox search after nixos-wiki changes left it in a bad state.
- Update Apple date format strings
- Overhaul Git post-checkout hook – it makes more effort and is less likely to fail.
- Don’t override local DNS with Tailscale, since it now works without it.