### PR TITLE
Remove use of the Garnix cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,12 +7,8 @@
     allow-import-from-derivation = true;
     ## https://github.com/NixOS/rfcs/blob/master/rfcs/0045-deprecate-url-syntax.md
     extra-experimental-features = ["no-url-literals"];
-    extra-substituters = [
-      "https://cache.garnix.io"
-      "https://sellout.cachix.org"
-    ];
+    extra-substituters = ["https://sellout.cachix.org"];
     extra-trusted-public-keys = [
-      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
       "sellout.cachix.org-1:v37cTpWBEycnYxSPAgSQ57Wiqd3wjljni2aC0Xry1DE="
     ];
     ## Isolate the build.

--- a/nix/modules/home-configuration.nix
+++ b/nix/modules/home-configuration.nix
@@ -38,7 +38,8 @@
   age.secretsDir = "${config.lib.local.xdg.runtimeDir}/agenix";
 
   garnix.cache = {
-    enable = true;
+    ## This service is now dead, but may rise again.
+    enable = false;
     config = "on";
   };
 

--- a/nix/modules/system-configuration.nix
+++ b/nix/modules/system-configuration.nix
@@ -33,7 +33,8 @@
   ## Don’t let Home Manager conflicts get in the way of system updates.
   home-manager.backupFileExtension = "before-home-manager";
 
-  garnix.cache.enable = true;
+  ## This service is now dead, but may rise again.
+  garnix.cache.enable = false;
 
   nix = {
     ## Remove old-style tools & configs, preferring flakes.


### PR DESCRIPTION
The service is no longer running, so we can’t use it.