### PR TITLE
Remove Eagle from `allowedUnfreePackages`

### DIFF
--- a/nix/modules/home-configuration.nix
+++ b/nix/modules/home-configuration.nix
@@ -483,7 +483,6 @@
   local.nixpkgs = {
     enable = true;
     allowedUnfreePackages = [
-      "eagle"
       "plex-desktop"
       "plexmediaserver"
     ];


### PR DESCRIPTION
We no longer install the app, so we don’t need the exception.